### PR TITLE
##Issue: fieldSchema for field group_id cannot be null

### DIFF
--- a/src/main/java/com/taosdata/kafka/connect/source/TableMapper.java
+++ b/src/main/java/com/taosdata/kafka/connect/source/TableMapper.java
@@ -155,6 +155,7 @@ public abstract class TableMapper {
                 return Schema.OPTIONAL_INT32_SCHEMA;
             case "TIMESTAMP":
             case "BIGINT":
+            case "BIGINT UNSIGNED":
                 return Schema.OPTIONAL_INT64_SCHEMA;
             case "FLOAT":
                 return Schema.OPTIONAL_FLOAT32_SCHEMA;


### PR DESCRIPTION
The data type BIGINT UNSIGNED was not handled. The TableMapper.convertType function does not handle BIGINT UNSIGNED in its switch case. This Data type is created for stable when creating a stream because of this the connector crashed.

Issue-73. I have elaborated more on this issue with screenshot.